### PR TITLE
Hide error while loading postgress

### DIFF
--- a/app-monolith/src/main/resources/application-docker.properties
+++ b/app-monolith/src/main/resources/application-docker.properties
@@ -1,3 +1,4 @@
 spring.datasource.url=jdbc:postgresql://database:5432/postgres
 spring.datasource.username=postgres
 spring.datasource.password=postgres
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true


### PR DESCRIPTION
Problem: When loading monolith-app posgress error is visible with long stack trace
Solution : Change hibernate lob settings to silence this error. 