### PR TITLE
gradle build with docker fixed

### DIFF
--- a/app-monolith/Dockerfile
+++ b/app-monolith/Dockerfile
@@ -2,5 +2,5 @@ FROM openjdk:8u171-jdk-alpine3.7
 MAINTAINER Michał Michaluk <michal.michaluk@bottega.com.pl>
 
 EXPOSE 8080
-COPY target/app.jar app.jar
+COPY build/libs/app.jar app.jar
 ENTRYPOINT ["java", "-jar","/app.jar", "--spring.profiles.active=docker"]

--- a/app-monolith/build.gradle
+++ b/app-monolith/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
 [bootJar, bootRun]*.enabled = true
 jar.enabled = false
+bootJar.archiveName='app.jar'
 
 task stubsJar(type: Jar) {
     classifier = "stubs"


### PR DESCRIPTION
Dockerfile for app-monolith has bad path for build artifact. Artifact no longer has version within name and docker image source path is now fixed