### PR TITLE
New query for current demand per day introduced

### DIFF
--- a/demand-forecasting-adapters/src/main/java/io/dddbyexamples/factory/demand/forecasting/projection/CurrentDemandDao.java
+++ b/demand-forecasting-adapters/src/main/java/io/dddbyexamples/factory/demand/forecasting/projection/CurrentDemandDao.java
@@ -16,8 +16,12 @@ import java.util.Optional;
         collectionResourceRel = "demand-forecasts",
         itemResourceRel = "demand-forecast")
 public interface CurrentDemandDao extends ProjectionRepository<CurrentDemandEntity, Long> {
+    @Deprecated
     @RestResource(path = "refNos", rel = "refNos")
     List<CurrentDemandEntity> findByRefNoAndDateGreaterThanEqual(@Param("refNo") String refNo, @Param("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)  LocalDate date);
+
+    @RestResource(path = "byDate")
+    List<CurrentDemandEntity> findByDate(LocalDate date);
 
     @RestResource(exported = false)
     Optional<CurrentDemandEntity> findByRefNoAndDate(String refNo, LocalDate date);


### PR DESCRIPTION
It turned out that adapter on delivery planning module would require a different rest repo endpoint that already prepared - it was added in the PR. As findByRefNoAndDateGreaterThanEqual is no needed any more it is marked as deprecated, and will be removed in subsequent pull requests.